### PR TITLE
Fix bug when reading MRR raw files with some missing/corrupt data

### DIFF
--- a/IMProToo/core.py
+++ b/IMProToo/core.py
@@ -2011,7 +2011,9 @@ class mrrProcessedData:
                         raise IOError("could not open:" + file)
                 else:
                     try:
-                        allData = open(file, 'r')
+		        # without errors='ignore', post-processing script crashes 
+			# when loading MRR raw file with some missing/corrupt data
+                        allData = open(file, 'r', errors='ignore')
                     except:
                         print("could not open:", file)
                         raise IOError("could not open:" + file)
@@ -2492,7 +2494,9 @@ class mrrRawData:
                         raise IOError("could not open:" + file)
                 else:
                     try:
-                        allData = open(file, 'r')
+		        # without errors='ignore', post-processing script crashes 
+			# when loading MRR raw file with some missing/corrupt data
+                        allData = open(file, 'r', errors='ignore')
                     except:
                         print("could not open:", file)
                         raise IOError("could not open:" + file)

--- a/IMProToo/core.py
+++ b/IMProToo/core.py
@@ -2011,8 +2011,8 @@ class mrrProcessedData:
                         raise IOError("could not open:" + file)
                 else:
                     try:
-		        # without errors='ignore', post-processing script crashes 
-			# when loading MRR raw file with some missing/corrupt data
+                        # without errors='ignore', post-processing script crashes 
+                        # when loading MRR raw file with some missing/corrupt data
                         allData = open(file, 'r', errors='ignore')
                     except:
                         print("could not open:", file)
@@ -2494,8 +2494,8 @@ class mrrRawData:
                         raise IOError("could not open:" + file)
                 else:
                     try:
-		        # without errors='ignore', post-processing script crashes 
-			# when loading MRR raw file with some missing/corrupt data
+                        # without errors='ignore', post-processing script crashes 
+                        # when loading MRR raw file with some missing/corrupt data
                         allData = open(file, 'r', errors='ignore')
                     except:
                         print("could not open:", file)


### PR DESCRIPTION
**Summary:**
Bug fix for handing batch script Python 3 post-processing of MRR raw data files that have missing/corrupt data.

**Longer description:**
I have been running IMProToo v0.103 with Python 2.7 in real time to process and plot the data from my advisor's MRR-2. However, this older MRR-2 frequently outputs errors in its raw files, for example:
```
Checksum Error on line: "F61 ... 
Checksum Error on line: "F62 ...
Checksum Error on line: "F63 ...
```

I recently upgraded my version of IMProToo to v0.104 run with Python 3.6, so I could remove my dependence on Python 2.7. When I did so, I noticed the post-processing script I was running (based on examples/batch_convert_rawData.py) printed "could not read data" and did not output a netCDF file on days when "Checksum Error" appeared in the .raw file. The specific traceback looks like:
```python
Traceback (most recent call last):
  File "mrr_post_process_v0104.py", line 54, in <module>
    rawData = IMProToo.mrrRawData(rawfile)
  File "/my/code/directory/IMProToo/core.py", line 2521, in __init__
    for line in allData:
  File "/linuxapps/anaconda3/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x98 in position 4481: invalid start byte
```

After looking at the IMProToo source code, I traced the error to the `open()` call on the raw file in core.py:
```python
allData = open(file, 'r')
```
My hunch is that since Python 3 seems to expect more strict Unicode formatting when it reads data, it chokes here on the corrupt raw file while Python 2 does not. However, I found that if I add the following to the `open()` call, I am able to read the raw files even with errors since this skips the error lines:
```python
allData = open(file, 'r', errors='ignore')
```
There might be a more robust way to handle this error case, since the Python docs give the [warning](https://docs.python.org/3/library/functions.html#open) that errors='ignore' might lead to data loss. Nonetheless, the output  streams of warning text after post-processing are nearly identical between this version and my copy of IMProToo v0.103, suggesting the same amount of data is retained as v0.103 seemed to do implicitly with Python 2. Maybe we just have a bad MRR-2, but hopefully you may find this useful!
