### PR TITLE
Py27 and timezone bugfixes

### DIFF
--- a/IMProToo/core.py
+++ b/IMProToo/core.py
@@ -40,6 +40,7 @@ from copy import deepcopy
 import warnings
 import sys
 import os
+import codecs
 
 from .tools import unix2date, date2unix, limitMaInidces, quantile
 from .tools import oneD2twoD, _get_netCDF_module
@@ -2496,7 +2497,9 @@ class mrrRawData:
                     try:
                         # without errors='ignore', post-processing script crashes 
                         # when loading MRR raw file with some missing/corrupt data
-                        allData = open(file, 'r', errors='ignore')
+                        # using codecs.open(... encoding='UTF-8' ...) as this seems to be
+                        # the only method that works in python 2 and 3.
+                        allData = codecs.open(file, 'r', encoding='UTF-8', errors='ignore')
                     except:
                         print("could not open:", file)
                         raise IOError("could not open:" + file)

--- a/IMProToo/core.py
+++ b/IMProToo/core.py
@@ -2431,6 +2431,14 @@ class mrrRawData:
                 self.mrrRawSpectrum = cdfFile.variables['MRR_Spectra'][:]
                 self.mrrRawNoSpec = cdfFile.variables['MRR_NoSpectra'][:]
 
+                try:
+                    self.timezone = str(cdfFile.variables['MRR time'].timezone)
+                except AttributeError:
+                    # this can occur when loading a file created with an older
+                    # version of IMProToo, before the timezone update.
+                    warnings.warn("timezone attribute missing, assuming UTC")
+                    self.timezone = "UTC"
+
                 cdfFile.close()
 
                 self.shape2D = np.shape(self.mrrRawHeight)

--- a/IMProToo/core.py
+++ b/IMProToo/core.py
@@ -2014,7 +2014,9 @@ class mrrProcessedData:
                     try:
                         # without errors='ignore', post-processing script crashes 
                         # when loading MRR raw file with some missing/corrupt data
-                        allData = open(file, 'r', errors='ignore')
+                        # using codecs.open(... encoding='UTF-8' ...) as this seems to be
+                        # the only method that works in python 2 and 3.
+                        allData = codecs.open(file, 'r', encoding='UTF-8', errors='ignore')
                     except:
                         print("could not open:", file)
                         raise IOError("could not open:" + file)


### PR DESCRIPTION
two bug fixes: the first makes the open( ) call work in python2 and python3 by replacing with a lower level call to codecs.open( ). This seems to be the only way to get identical behavior in python2 and python3.

The second makes sure the timezone is read from a netCDF-converted raw file. Without the fix, the timezone attribute is None, which causes an error when writing to netCDF. This should be easy to reproduce:

```python
r0 = IMProToo.mrrRawData("0101.raw")
r0.writeNetCDF('tmp0.nc')
r1 = IMProToo.mrrRawData('tmp0.nc')
r1.writeNetCDF('tmp1.nc')
```

The second writeNetCDF call will fail with a netCDF "illegal data type" error.